### PR TITLE
Remove Navali dialogue steps

### DIFF
--- a/all-ears-unturned/assets/steps.json
+++ b/all-ears-unturned/assets/steps.json
@@ -120,18 +120,6 @@
      "destination":"The Climb"
   },
   { 
-     "event":"Rescue Navali"
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":[ 
-        "Introduction",
-        "Wraeclast",
-        "Yama the White",
-        "Karui Gods"
-     ]
-  },
-  { 
      "destination":"The Lower Prison"
   },
   { 
@@ -287,10 +275,6 @@
   { 
      "NPC":"Silk",
      "subjects":"Greust"
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":"Introduction"
   },
   { 
      "destination":"The Old Fields"
@@ -604,10 +588,6 @@
      "subjects":"The Ebony Legion"
   },
   { 
-     "NPC":"Navali",
-     "subjects":"Introduction"
-  },
-  { 
      "destination":"The Slums"
   },
   { 
@@ -891,10 +871,6 @@
         "Trading",
         "The Beast"
      ]
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":"Introduction"
   },
   { 
      "NPC":"Oyun",
@@ -1221,10 +1197,6 @@
   { 
      "NPC":"Lani",
      "subjects":"Vilenta"
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":"Introduction"
   },
   { 
      "event":"Kill Justicar Casticus"
@@ -2203,7 +2175,7 @@
      "event":"Kill Kitava"
   },
   { 
-     "destination":"Oriath"
+     "destination":"Oriath Docks"
   },
   { 
      "NPC":"Innocence",
@@ -2220,34 +2192,5 @@
   { 
      "NPC":"Weylam Roth",
      "subjects":"Kitava"
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":[ 
-        "Anarchy's End",
-        "Day of Sacrifice",
-        "Beyond Sight",
-        "The Warmongers",
-        "Deadly Rivalry",
-        "The Plaguemaw",
-        "The Feral Lord",
-        "Unbearable Whispers",
-        "The Unbreathing Queen",
-        "Thaumaturgical History",
-        "The Ambitious Bandit"
-     ],
-     "note":"You must complete the first step of the named prophecy chain first"
-  },
-  { 
-     "event":[ 
-        "Complete 'The Plaguemaw V' Prophecy",
-        "Complete 'The Feral Lord V' Prophecy",
-        "Complete 'Unbearable Whispers V' Prophecy",
-        "Complete 'The Unbreathing Queen V' Prophecy"
-     ]
-  },
-  { 
-     "NPC":"Navali",
-     "subjects":"The Pale Court"
   }
 ]

--- a/all-ears-unturned/src/AllEarsManager.cpp
+++ b/all-ears-unturned/src/AllEarsManager.cpp
@@ -38,9 +38,9 @@ void AllEarsManager::Render()
 
 	auto npc_step = dynamic_cast<NpcStep*>(steps_[current_step_].get());
 	if (npc_step){
-		ImGui::Text("Progress: %d / %d", num_dialogs_completed_ + npc_step->dialogs_completed_, 505);
+		ImGui::Text("Progress: %d / %d", num_dialogs_completed_ + npc_step->dialogs_completed_, num_dialogs_total_);
 	} else {
-		ImGui::Text("Progress: %d / %d", num_dialogs_completed_, 505);
+		ImGui::Text("Progress: %d / %d", num_dialogs_completed_, num_dialogs_total_);
 	}
 	ImGui::Separator();
 

--- a/all-ears-unturned/src/AllEarsManager.h
+++ b/all-ears-unturned/src/AllEarsManager.h
@@ -21,6 +21,6 @@ public:
 	std::vector<std::unique_ptr<Step>> steps_;
 	int current_step_ = 0;
 	int num_dialogs_completed_ = 0;
-	const int num_dialogs_total_ = 505;
+	const int num_dialogs_total_ = 484;
 	bool achievement_complete_ = false;
 };


### PR DESCRIPTION
Resolves #14 

I built this locally and used it to get the achievement in 3.17.  The very end was a little unexpected as I got the achievement one dialogue earlier than expected. 

Also the end of Act 10 changed so you now return to the Oriath Docks to talk to everyone, rather than go to an in-repair Oriath.